### PR TITLE
Add iterator traits

### DIFF
--- a/include/mapbox/eternal.hpp
+++ b/include/mapbox/eternal.hpp
@@ -162,7 +162,7 @@ public:
         return *this;
     }
 
-    constexpr std::size_t operator-(const iterator& rhs) const noexcept {
+    constexpr std::ptrdiff_t operator-(const iterator& rhs) const noexcept {
         return pos - rhs.pos;
     }
 
@@ -330,6 +330,19 @@ static constexpr auto hash_map(const std::pair<const Key, const Value> (&items)[
 
 } // namespace eternal
 } // namespace mapbox
+
+namespace std {
+
+template <typename Element>
+struct iterator_traits<::mapbox::eternal::iterator<Element>> {
+    using difference_type = std::ptrdiff_t;
+    using value_type = typename Element::value_type;
+    using pointer = Element*;
+    using reference = Element&;
+    using iterator_category = std::bidirectional_iterator_tag;
+};
+
+} // namespace std
 
 // mapbox::eternal::string
 

--- a/test/data.hpp
+++ b/test/data.hpp
@@ -17,6 +17,13 @@ struct Color {
         return r == rhs.r && g == rhs.g && b == rhs.b &&
                (a >= rhs.a ? a - rhs.a : rhs.a - a) < std::numeric_limits<float>::epsilon();
     }
+
+    constexpr bool operator<(const Color& rhs) const {
+        return r < rhs.r ||
+            (!(rhs.r < r) && g < rhs.g) ||
+            (!(rhs.g < g) && b < rhs.b) ||
+            (!(rhs.b < b) && a < rhs.a);
+    }
 };
 
 #define COLORS                                                                                     \

--- a/test/map.test.cpp
+++ b/test/map.test.cpp
@@ -1,5 +1,7 @@
 #include "data.hpp"
 
+#include <algorithm>
+
 #include <cassert>
 
 
@@ -67,6 +69,8 @@ static void test() {
     for (auto range = multi_colors.equal_range("yellow"); range.first != range.second; ++range.first) {
         (void)range;
     }
+
+    assert(std::is_sorted(colors.begin(), colors.end()));
 }
 
 int main(int argc, char* argv[]) {


### PR DESCRIPTION
Incorporating @jan-moeller's suggestion from #2.

There are a few caveats with this: I changed the `value_type` to `typename Element::value_type`. The `element` wrapper is used for custom comparisons inside an `eternal::map`, but the dereference operator returns the encapsulated `std::pair`. This means that STL algorithms will get the `std::pair` and call its operators, e.g. when comparing. This may be fine for your use case, but it's different from the `eternal` sort order, which is based on the key exclusively and never on the value. This only matters when you use `eternal::map/hash_map` as a multimap (i.e. with duplicate keys).

An alternative could be to derive `element` from `std::pair` instead of wrapping it. We can't use `std::pair` directly because its comparison operators aren't `constexpr` in C++11, their `std::swap` specialization isn't `constexpr` until C++20, and for `element_hash`, we need a custom hashing comparator.