### PR TITLE
Fix template argument evaluation for hash offset values

### DIFF
--- a/include/mapbox/eternal.hpp
+++ b/include/mapbox/eternal.hpp
@@ -340,12 +340,12 @@ namespace impl {
 // Use different constants for 32 bit vs. 64 bit size_t
 constexpr std::size_t hash_offset =
     std::conditional_t<sizeof(std::size_t) < 8,
-                       std::integral_constant<std::size_t, 0x811C9DC5>,
-                       std::integral_constant<std::size_t, 0xCBF29CE484222325>>::value;
+                       std::integral_constant<std::uint32_t, 0x811C9DC5>,
+                       std::integral_constant<std::uint64_t, 0xCBF29CE484222325>>::value;
 constexpr std::size_t hash_prime =
     std::conditional_t<sizeof(std::size_t) < 8,
-                       std::integral_constant<std::size_t, 0x1000193>,
-                       std::integral_constant<std::size_t, 0x100000001B3>>::value;
+                       std::integral_constant<std::uint32_t, 0x1000193>,
+                       std::integral_constant<std::uint64_t, 0x100000001B3>>::value;
 
 // FNV-1a hash
 constexpr static std::size_t str_hash(const char* str,


### PR DESCRIPTION
Use 64 and 32 bit unsigned integers explicitly to avoid compilers throwing narrowing errors.

```
In file included from ./src/mbgl/style/layers/symbol_layer.cpp:16:
./vendor/eternal/include/mapbox/eternal.hpp:344:60: error: non-type template argument evaluates to 14695981039346656037, which cannot be narrowed to type 'unsigned long' [-Wc++11-narrowing]
                       std::integral_constant<std::size_t, 0xCBF29CE484222325>>::value;
                                                           ^
./vendor/eternal/include/mapbox/eternal.hpp:348:60: error: non-type template argument evaluates to 1099511628211, which cannot be narrowed to type 'unsigned long' [-Wc++11-narrowing]
                       std::integral_constant<std::size_t, 0x100000001B3>>::value;
```

Another option is to use explicit static cast for hex literals, e.g., `std::integral_constant<std::size_t, static_cast<std::size_t>(0x100000001B3)>` 