### PR TITLE
Allow eternal to be used as a subdirectory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 add_library(eternal INTERFACE)
-target_include_directories(eternal SYSTEM INTERFACE ${CMAKE_SOURCE_DIR}/include)
+target_include_directories(eternal SYSTEM INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
 option(WITH_TESTS "Enable tests" ON)
 if (WITH_TESTS)


### PR DESCRIPTION
Kind of strange it hasn't been caught before, but using `CMAKE_SOURCE_DIR` always refers to the root-most CMake project, not the Eternal directory (wherever it might exist).

Changing it to `CMAKE_CURRENT_SOURCE_DIR` allows Eternal to properly set up the include paths of the interface target to refer to the subdirectory's location instead of the project root (which makes no sense).