### PR TITLE
allow using eternal through CPM/cmake package management system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 add_library(eternal INTERFACE)
-target_include_directories(eternal SYSTEM INTERFACE ${CMAKE_SOURCE_DIR}/include)
+target_include_directories(eternal SYSTEM INTERFACE ./include)
 
 option(WITH_TESTS "Enable tests" ON)
 if (WITH_TESTS)


### PR DESCRIPTION
Hi, this minor change allows using eternal with cmake's `Fetch_Conent` or alternatively [CPM](https://github.com/cpm-cmake/CPM.cmake).

The current way that the include folder are specified means that an including cmake project will be providing its own source directory as the `CMAKE_SOURCE_DIR` preventing cmake from supplying the correct `-I` directives.