### PR TITLE
Adds wide-string support to `mapbox::eternal::string`

### DIFF
--- a/include/mapbox/eternal.hpp
+++ b/include/mapbox/eternal.hpp
@@ -349,59 +349,65 @@ constexpr std::size_t hash_prime =
                        std::integral_constant<uint64_t, 0x100000001B3>>::value;
 
 // FNV-1a hash
-constexpr static std::size_t str_hash(const char* str,
+template <typename CharT>
+constexpr static std::size_t str_hash(const CharT* str,
                                       const std::size_t value = hash_offset) noexcept {
     return *str ? str_hash(str + 1, (value ^ static_cast<std::size_t>(*str)) * hash_prime) : value;
 }
 
-constexpr bool str_less(const char* lhs, const char* rhs) noexcept {
+template <typename CharT> constexpr bool str_less(const CharT* lhs, const CharT* rhs) noexcept {
     return *lhs && *rhs && *lhs == *rhs ? str_less(lhs + 1, rhs + 1) : *lhs < *rhs;
 }
 
-constexpr bool str_equal(const char* lhs, const char* rhs) noexcept {
-    return *lhs == *rhs && (*lhs == '\0' || str_equal(lhs + 1, rhs + 1));
+template <typename CharT> constexpr bool str_equal(const CharT* lhs, const CharT* rhs) noexcept {
+    return *lhs == *rhs && (*lhs == static_cast<CharT>(0) || str_equal(lhs + 1, rhs + 1));
 }
 
 } // namespace impl
 
-class string {
+template <typename CharT>
+class basic_string {
 private:
-    const char* data_;
+    const CharT* data_;
 
 public:
-    constexpr string(char const* data) noexcept : data_(data) {
+    constexpr basic_string(const CharT* data) noexcept : data_(data) {
     }
 
-    constexpr string(const string&) noexcept = default;
-    constexpr string(string&&) noexcept = default;
-    MAPBOX_ETERNAL_CONSTEXPR string& operator=(const string&) noexcept = default;
-    MAPBOX_ETERNAL_CONSTEXPR string& operator=(string&&) noexcept = default;
+    constexpr basic_string(const basic_string&) noexcept = default;
+    constexpr basic_string(basic_string&&) noexcept = default;
+    MAPBOX_ETERNAL_CONSTEXPR basic_string& operator=(const basic_string&) noexcept = default;
+    MAPBOX_ETERNAL_CONSTEXPR basic_string& operator=(basic_string&&) noexcept = default;
 
-    constexpr bool operator<(const string& rhs) const noexcept {
+    constexpr bool operator<(const basic_string& rhs) const noexcept {
         return impl::str_less(data_, rhs.data_);
     }
 
-    constexpr bool operator==(const string& rhs) const noexcept {
+    constexpr bool operator==(const basic_string& rhs) const noexcept {
         return impl::str_equal(data_, rhs.data_);
     }
 
-    constexpr const char* data() const noexcept {
+    constexpr const CharT* data() const noexcept {
         return data_;
     }
 
-    constexpr const char* c_str() const noexcept {
+    constexpr const CharT* c_str() const noexcept {
         return data_;
     }
 };
+
+
+using string = basic_string<char>;
+using wstring = basic_string<wchar_t>;
 
 } // namespace eternal
 } // namespace mapbox
 
 namespace std {
 
-template <>
-struct hash<::mapbox::eternal::string> {
-    constexpr std::size_t operator()(const ::mapbox::eternal::string& str) const {
+template <typename CharT>
+struct hash<::mapbox::eternal::basic_string<CharT>> {
+    constexpr std::size_t operator()(const ::mapbox::eternal::basic_string<CharT>& str) const {
         return ::mapbox::eternal::impl::str_hash(str.data());
     }
 };

--- a/test/map.test.cpp
+++ b/test/map.test.cpp
@@ -21,6 +21,11 @@ MAPBOX_ETERNAL_CONSTEXPR const auto hash_colors = mapbox::eternal::hash_map<mapb
     { "white", { 255, 255, 255, 1 } },
 });
 
+MAPBOX_ETERNAL_CONSTEXPR const auto hash_colors_wide = mapbox::eternal::hash_map<mapbox::eternal::wstring, Color>({
+    { L"yellow", { 255, 255, 0, 1 } },
+    { L"yellow", { 255, 220, 0, 1 } },  // a darker yellow
+});
+
 // GCC 4.9 compatibility
 #if MAPBOX_ETERNAL_IS_CONSTEXPR
 #define CONSTEXPR_ASSERT(value, str) static_assert(value, str)
@@ -57,6 +62,9 @@ static void test() {
     CONSTEXPR_ASSERT(hash_colors.equal_range("white").first == hash_colors.find("white"), "white range returns the correct begin");
     CONSTEXPR_ASSERT(hash_colors.equal_range("yellow").first == hash_colors.find("yellow"), "yellow range returns the correct begin");
     CONSTEXPR_ASSERT(hash_colors.count("yellow") == 2, "has 2 yellows");
+    
+    CONSTEXPR_ASSERT(hash_colors_wide.find(L"yellow") != hash_colors_wide.end(), "colors contains yellow (wide)");
+    CONSTEXPR_ASSERT(hash_colors_wide.count(L"yellow") == 2, "has 2 yellows (wide)");
 
     // Can use range-for
     for (auto& x : colors) {


### PR DESCRIPTION
- Templated `str_*` helpers with `CharT` argument
- Introduces `mapbox::eternal::basic_string<CharT>` and provides `string`/`wstring` aliases with `CharT` = `char`/`wchar_t`.